### PR TITLE
Add support for chunked transfer encoding data streaming

### DIFF
--- a/http.lua
+++ b/http.lua
@@ -443,12 +443,52 @@ function M.send(method, t)
             end
         end
 
+        if r.headers["transfer-encoding"] and r.headers["transfer-encoding"] == "chunked" then
+            local chunks = core.concat()
+            while true do
+                local chunk, err = M.receive_chunk(socket)
+                if not chunk then
+                    socket:close()
+                    return nil, "http." .. method:lower() .. ": Receive error (content): "  .. err
+                else
+                    if chunk ~= "" then
+                        chunks:add(chunk)
+                    else
+                        break
+                    end
+                end
+            end
+            r.content = chunks:dump()
+        end
+
         socket:close()
         return r
     else
         return nil, "http." .. method:lower() .. ": Connection error: " ..
                schema .. "://" .. addr .. ":" .. port
     end
+end
+
+--- Reads one chunk from a HTTP response
+--
+-- @param socket socket ojbect (with already established tcp connection)
+--
+-- @return chunk recieved chunk or nil and an error message
+M.receive_chunk = function(socket)
+
+    local length, err = socket:receive("*l")
+    if length then
+        if length == "" then
+            return ""
+        end
+        local chunk
+        chunk, err = socket:receive("*l")
+        if chunk then
+            return chunk
+        end
+    end
+    return nil, "http." .. method:lower() .. ": Chunk receive error: "  .. err
+
 end
 
 M.base64 = {}


### PR DESCRIPTION
[Chunked transfer encoding](https://en.wikipedia.org/wiki/Chunked_transfer_encoding) is an essential part of HTTP/1.1, so it's nice to have this case covered. 