### PR TITLE
Fix multipart/form-data boundary parsing

### DIFF
--- a/http.lua
+++ b/http.lua
@@ -378,7 +378,7 @@ function M.request.parse_multipart(self)
         local old_i
 
         while true do
-            i, j = body:find(boundary, i)
+            i, j = body:find('--' .. boundary, i)
 
             if i == nil then break end
 


### PR DESCRIPTION
I've spent several hours troubleshooting an issue where I couldn't get a simple plain python3 script to emulate a cURL request against haproxy-lua-acme, powered by haproxy-lua-http.

As it turns out, cURL uses boundaries like this:
```
----------------------e45e387473048941
````

while python's httplib uses boundaries like this:
```
6bc4c0b431e13fda6748fe624a1002c9
```

However, those boundaries are all prefixed by `--`, as per https://tools.ietf.org/html/rfc7578#section-4.1, to separate parts.
On cURL-style boundaries, `M.request.parse_multipart` does fine, but it chokes on python's dash-less boundaries and mixes up the boundary prefix and the boundary itself.

This PR aims to fix that. I've applied that patch to my httpd.lua and I've been able to do the same request using cURL as python3.

I am no Lua developper by any stretch of the imagination so do not hesitate to point out issues, even if the fix is small.