### PR TITLE
Add IPv6 Address Support to Host Header

### DIFF
--- a/http.lua
+++ b/http.lua
@@ -681,7 +681,12 @@ function M.send(method, t)
 
         if not t.headers.host then
             -- 'Host' header must be provided for HTTP/1.1
-            table.insert(hdr_tbl, "host: " .. host)
+            if addr:find(":") and not addr:match("^%[.*%]$") then
+                -- Enclose IPv6 addresses in square brackets
+                table.insert(hdr_tbl, string.format("host: [%s]:%s", addr, port))
+            else
+                table.insert(hdr_tbl, "host: " .. host)
+            end
         end
 
         if not t.headers["accept"] then


### PR DESCRIPTION
RFC 3986 requires square brackets on IPv6 addresses. This PR updates the Host header and fixes HTTP 400 Bad Request errors.